### PR TITLE
shutdown in all threads

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -388,13 +388,15 @@ class Net::HTTP::Persistent
   end
 
   ##
-  # Shuts down all connections in this thread.
+  # Shuts down all connections in a thread.
+  # 
+  # Uses the current thread by default.
   #
   # If you've used Net::HTTP::Persistent across multiple threads you must call
-  # this in each thread.
+  # this for each thread.
 
-  def shutdown
-    connections = Thread.current[@connection_key]
+  def shutdown thread = Thread.current
+    connections = thread[@connection_key]
 
     connections.each do |_, connection|
       begin
@@ -403,8 +405,15 @@ class Net::HTTP::Persistent
       end
     end if connections
 
-    Thread.current[@connection_key] = nil
-    Thread.current[@request_key]    = nil
+    thread[@connection_key] = nil
+    thread[@request_key]    = nil
+  end
+
+  ##
+  # Shuts down all connections in all threads
+  
+  def shutdown_in_all_threads
+    Thread.list.each { |t| shutdown t }
   end
 
   ##


### PR DESCRIPTION
Hello,

I'm a contributor to the ruote project. jmettraux, the maintainer, had some issues (connections kept beeing open) when testing ruote-couch, a storage adapter for ruote, when using net-http-persistent for connecting to the couch.

jmettraux solved this by doing some monkey patching: http://github.com/jmettraux/rufus-jig/blob/master/lib/rufus/jig/adapters/net_persistent.rb#L32-75

So, as you can see, the problem is not within net-http-persistent itself, but it would be helpful to have a helper method around which shuts down all connections in all threads. I agreed to prepare a patch for net-http-persistent so that we may drop the monkey patching.

Hope you like it, any comments are appreciated.

Cheers,
Torsten
