### PR TITLE
Add retry_change_requests option to allow users to configure auto-retry

### DIFF
--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -783,5 +783,17 @@ class TestNetHttpPersistent < MiniTest::Unit::TestCase
     assert_equal OpenSSL::SSL::VERIFY_NONE, c.verify_mode
   end
 
+  def test_can_retry_change_requests
+    get  = Net::HTTP::Get.new('/')
+    post = Net::HTTP::Post.new('/')
+    assert @http.can_retry?(get)
+    refute @http.retry_change_requests
+    refute @http.can_retry?(post)
+    @http.retry_change_requests = true
+    assert @http.can_retry?(get)
+    assert @http.retry_change_requests
+    assert @http.can_retry?(post)
+  end
+
 end
 


### PR DESCRIPTION
- Add retry_change_requests option to allow users to configure auto-retries of change requests (POST, PUT, etc) on IOErrors, Timeouts, etc

Currently it's inconvenient for many application authors to have to deal with server invoked connection timeouts, so this patch makes that convenient where it's generally accepted that duplicate requests could be caused by particularly adverse network conditions. The alternative is wrapper code or a substantial monkey patch:

``` ruby
require 'net/http/persistent'

if Net::HTTP::Persistent.instance_methods.include?(:can_retry?)

  warn "Deprecation: Net::HTTP::Persistent now supports patch in #{__FILE__}"

  class Net::HTTP::Persistent::AlwaysRetry < Net::HTTP::Persistent
    def initialize(*)
      super
      self.retry_change_requests = true
    end
  end
else
  # This is like Net::HTTP::Persistent except that it will retry idempotent
  # requests (i.e. POSTS) under IO error and bad response conditions. This could
  # in theory be dangerous.
  class Net::HTTP::Persistent::AlwaysRetry < Net::HTTP::Persistent

    def request uri, req = nil, &block
      retried      = false
      bad_response = false

      req = Net::HTTP::Get.new uri.request_uri unless req

      headers.each do |pair|
        req.add_field(*pair)
      end

      req.add_field 'Connection', 'keep-alive'
      req.add_field 'Keep-Alive', @keep_alive

      connection = connection_for uri
      connection_id = connection.object_id

      begin
        Thread.current[@request_key][connection_id] += 1
        response = connection.request req, &block

      rescue Net::HTTPBadResponse => e
        message = error_message connection

        finish connection

        raise Error, "too many bad responses #{message}" if bad_response

        bad_response = true
        retry
      rescue IOError, EOFError, Timeout::Error,
        Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE,
        Errno::EINVAL => e

        if retried
          due_to = "(due to #{e.message} - #{e.class})"
          message = error_message connection

          finish connection

          raise Error, "too many connection resets #{due_to} #{message}"
        end

        reset connection

        retried = true
        retry
      end
    end

  end
end
```
