### PR TITLE
Two fixes for certain classes of idle connection timeout with SSL.

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'net/https'
 require 'net/http/faster'
 require 'uri'
 require 'cgi' # for escaping
@@ -435,7 +436,7 @@ class Net::HTTP::Persistent
       retry
     rescue IOError, EOFError, Timeout::Error,
            Errno::ECONNABORTED, Errno::ECONNRESET, Errno::EPIPE,
-           Errno::EINVAL => e
+           Errno::EINVAL, OpenSSL::SSL::SSLError => e
 
       if retried or not can_retry? req
         due_to = "(due to #{e.message} - #{e.class})"
@@ -506,7 +507,6 @@ class Net::HTTP::Persistent
   # Enables SSL on +connection+
 
   def ssl connection
-    require 'net/https'
     connection.use_ssl = true
 
     # suppress warning but allow override

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -473,6 +473,19 @@ class TestNetHttpPersistent < MiniTest::Unit::TestCase
     assert_match %r%connection refused%, e.message
   end
 
+  def test_ssl_error
+    uri = URI.parse 'https://example.com/path'
+    c = @http.connection_for uri
+    def c.request(*)
+      raise OpenSSL::SSL::SSLError, "SSL3_WRITE_PENDING:bad write retry"
+    end
+
+    e = assert_raises Net::HTTP::Persistent::Error do
+      @http.request uri
+    end
+    assert_match %r%bad write retry%, e.message
+  end
+
   def test_request
     @http.headers['user-agent'] = 'test ua'
     c = connection


### PR DESCRIPTION
- Add retry protection for OpenSSL::SSL::SSLError
- Move require of net/https to the top of the file. It's now a dependency.
