### PR TITLE
Add support for cert_store

### DIFF
--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -774,6 +774,29 @@ class TestNetHttpPersistent < MiniTest::Unit::TestCase
     assert_equal :callback, c.verify_callback
   end
 
+  def test_ssl_cert_store
+    store = OpenSSL::X509::Store.new
+    @http.cert_store = store
+
+    c = Net::HTTP.new 'localhost', 80
+
+    @http.ssl c
+
+    assert c.use_ssl?
+    assert_equal store, c.cert_store
+  end
+
+  def test_default_cert_store
+    @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+    c = Net::HTTP.new 'localhost', 80
+
+    @http.ssl c
+
+    assert c.use_ssl?
+    assert c.cert_store
+  end
+
   def test_ssl_certificate
     @http.certificate = :cert
     @http.private_key = :key


### PR DESCRIPTION
This makes it easy for users to use the default system ca certificates, as VERIFY_PEER will "just work" provided they have root certificates installed in OPENSSLDIR (see `openssl version -d`) under cert.pem.

Users can also specify their own cert_store if desired.
