### PR TITLE
always set cert store to system default if not passed in

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -522,7 +522,7 @@ class Net::HTTP::Persistent
   def ssl connection
     connection.use_ssl = true
 
-    connection.verify_mode = OpenSSL::SSL::VERIFY_PEER unless @verify_mode
+    connection.verify_mode = @verify_mode || OpenSSL::SSL::VERIFY_PEER
 
     if @ca_file then
       connection.ca_file = @ca_file
@@ -535,16 +535,12 @@ class Net::HTTP::Persistent
       connection.key  = @private_key
     end
 
-    connection.cert_store = @cert_store if @cert_store
-
-    if @verify_mode then
-      connection.verify_mode = @verify_mode
-
-      connection.cert_store ||= begin
-        store = OpenSSL::X509::Store.new
-        store.set_default_paths
-        store
-      end
+    connection.cert_store = if @cert_store    
+      @cert_store
+    else
+      store = OpenSSL::X509::Store.new
+      store.set_default_paths
+      store
     end
   end
 


### PR DESCRIPTION
Pull request for issue #7.

Using ruby 1.8 it does not seem to be able to find the system certificate store without explicitly calling set_default_paths. This patch calls it even when @verify_mode is left as the default (verify peer).
