### PR TITLE
Fix a class of issues where HTTPResponse was not properly namespaced throwing an error when using a proxy and SSL connections from Mechanize.

### DIFF
--- a/lib/net/http/persistent/ssl_reuse.rb
+++ b/lib/net/http/persistent/ssl_reuse.rb
@@ -63,7 +63,7 @@ class Net::HTTP::Persistent::SSLReuse < Net::HTTP
             @socket.writeline "Proxy-Authorization: Basic #{credential}"
           end
           @socket.writeline ''
-          HTTPResponse.read_new(@socket).value
+          Net::HTTPResponse.read_new(@socket).value
         end
         # Server Name Indication (SNI) RFC 3546
         s.hostname = @address if s.respond_to? :hostname=
@@ -112,7 +112,7 @@ class Net::HTTP::Persistent::SSLReuse < Net::HTTP
           @socket.writeline "Proxy-Authorization: Basic #{credential}"
         end
         @socket.writeline ''
-        HTTPResponse.read_new(@socket).value
+        Net::HTTPResponse.read_new(@socket).value
       end
       s.connect
       if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
Fix a class of issues where HTTPResponse was not properly namespaced throwing an error when using a proxy and SSL connections from Mechanize.

Eliminates:

```
/tmp/mech_test/net-http-persistent/lib/net/http/persistent/ssl_reuse.rb:66:in
`connect': uninitialized constant Net::HTTP::Persistent::SSLReuse::HTTPResponse (NameError)
```

Similar to issue which originally brought us here:
http://bjhess.com/blog/make_sure_to_properly_scope_your_ruby_mixins/
