### PR TITLE
Fixed namespace issue

### DIFF
--- a/lib/net/http/persistent/ssl_reuse.rb
+++ b/lib/net/http/persistent/ssl_reuse.rb
@@ -112,7 +112,7 @@ class Net::HTTP::Persistent::SSLReuse < Net::HTTP
           @socket.writeline "Proxy-Authorization: Basic #{credential}"
         end
         @socket.writeline ''
-        HTTPResponse.read_new(@socket).value
+        Net::HTTPResponse.read_new(@socket).value
       end
       s.connect
       if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
This commit fixes an issue raised in the pull request at https://github.com/drbrain/net-http-persistent/pull/10, that was fixed incompletely in https://github.com/drbrain/net-http-persistent/commit/3fadf4a623a9b20b3260ba6fc6c0742ba5ba5ca5. I'm hitting this bug through Mechanize when I use a proxy.
