### PR TITLE
check if fakeweb or webmock are active to disable SSL session reuse automatically #13

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -452,7 +452,12 @@ class Net::HTTP::Persistent
   end
 
   def http_class # :nodoc:
-    @reuse_ssl_sessions ? Net::HTTP::Persistent::SSLReuse : Net::HTTP
+    if [:FakeWeb, :WebMock].any? { |klass| Object.const_defined?(klass) } or
+      not @reuse_ssl_sessions then
+        Net::HTTP
+    else
+      Net::HTTP::Persistent::SSLReuse
+    end
   end
 
   ##

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -273,6 +273,26 @@ class TestNetHttpPersistent < MiniTest::Unit::TestCase
     assert_instance_of Net::HTTP, c
   end
 
+  def test_connection_for_http_class_with_fakeweb
+    Object.send :const_set, :FakeWeb, nil
+    c = @http.connection_for @uri
+    assert_instance_of Net::HTTP, c
+  ensure
+    if Object.const_defined?(:FakeWeb) then
+      Object.send :remove_const, :FakeWeb
+    end
+  end
+
+  def test_connection_for_http_class_with_webmock
+    Object.send :const_set, :WebMock, nil
+    c = @http.connection_for @uri
+    assert_instance_of Net::HTTP, c
+  ensure
+    if Object.const_defined?(:WebMock) then
+      Object.send :remove_const, :WebMock
+    end
+  end
+
   def test_connection_for_proxy
     uri = URI.parse 'http://proxy.example'
     uri.user     = 'johndoe'


### PR DESCRIPTION
Added a patch for http_class() with tests for #13

Thanks Eric!
