### PR TITLE
Add #cert and #key aliases

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -190,6 +190,9 @@ class Net::HTTP::Persistent
 
   attr_reader :certificate
 
+  # For Net::HTTP parity
+  alias cert certificate
+
   ##
   # An SSL certificate authority.  Setting this will set verify_mode to
   # VERIFY_PEER.
@@ -268,6 +271,9 @@ class Net::HTTP::Persistent
   # This client's SSL private key
 
   attr_reader :private_key
+
+  # For Net::HTTP parity
+  alias key private_key
 
   ##
   # The URL through which requests will be proxied
@@ -419,6 +425,9 @@ class Net::HTTP::Persistent
 
     reconnect_ssl
   end
+
+  # For Net::HTTP parity
+  alias cert= certificate=
 
   ##
   # Sets the SSL certificate authority file.
@@ -679,6 +688,9 @@ class Net::HTTP::Persistent
 
     reconnect_ssl
   end
+
+  # For Net::HTTP parity
+  alias key= private_key=
 
   ##
   # Sets the proxy server.  The +proxy+ may be the URI of the proxy server,


### PR DESCRIPTION
Users familiar with Net::HTTP can use #cert and #key methods instead of #certificate and #private_key.

This also allows easier swapping in of Net::HTTP::Persistant for code that's already using Net::HTTP.
