### PR TITLE
Support for Artifice

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,9 @@
+=== 2.8.1 / 2012-07-12
+
+* Minor enhancement
+  * When Artifice is loaded SSL sessions will not be reused to prevent breakage
+    when testing with this framework.
+
 === 2.8 / 2012-06-11
 
 * Minor enhancement

--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -176,7 +176,7 @@ class Net::HTTP::Persistent
   ##
   # The version of Net::HTTP::Persistent you are using
 
-  VERSION = '2.8'
+  VERSION = '2.8.1'
 
   ##
   # Error class for errors raised by Net::HTTP::Persistent.  Various
@@ -620,7 +620,7 @@ class Net::HTTP::Persistent
   end
 
   def http_class # :nodoc:
-    if [:FakeWeb, :WebMock].any? { |klass| Object.const_defined?(klass) } or
+    if [:Artifice, :FakeWeb, :WebMock].any? { |klass| Object.const_defined?(klass) } or
       not @reuse_ssl_sessions then
         Net::HTTP
     else

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -373,6 +373,16 @@ class TestNetHttpPersistent < MiniTest::Unit::TestCase
     end
   end
 
+  def test_connection_for_http_class_with_artifice
+    Object.send :const_set, :Artifice, nil
+    c = @http.connection_for @uri
+    assert_instance_of Net::HTTP, c
+  ensure
+    if Object.const_defined?(:Artifice) then
+      Object.send :remove_const, :Artifice
+    end
+  end
+
   def test_connection_for_name
     http = Net::HTTP::Persistent.new 'name'
     uri = URI.parse 'http://example/'


### PR DESCRIPTION
When testing with [Artifice](https://github.com/wycats/artifice) you get the same sorts of issues reusing the SSL sessions with FakeWeb and WebMock.

This adds Artifice to the list of test frameworks supported. 
