### PR TITLE
Add Persistent#max_requests to prevent ECONNRESET

### DIFF
--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -646,6 +646,7 @@ class TestNetHttpPersistent < MiniTest::Unit::TestCase
 
   def test_expired_eh
     c = basic_connection
+    reqs[c.object_id] = 0
     touts[c.object_id] = Time.now - 11
 
     @http.idle_timeout = 0
@@ -662,6 +663,20 @@ class TestNetHttpPersistent < MiniTest::Unit::TestCase
 
     @http.idle_timeout = nil
     refute @http.expired? c
+  end
+
+  def test_expired_due_to_max_requests
+    c = basic_connection
+    reqs[c.object_id] = 0
+    touts[c.object_id] = Time.now
+
+    refute @http.expired? c
+
+    reqs[c.object_id] = 10
+    refute @http.expired? c
+
+    @http.max_requests = 10
+    assert @http.expired? c
   end
 
   def test_finish


### PR DESCRIPTION
- Many servers have a max_requests tunable on keepalive connections that is
  tuned to less than infinite. Some of these servers incorrectly close the
  connection out-of-band (rather than replying with Connection:close). In these
  cases, it is advantageous to avoid the resulting ECONNRESET, and preemptively
  reset those connections.
- Additional potential work that could be done later: Make a closing request on
  the last request. Add a detect_max_requests helper at the top level.
- Exmaple configuration link:
  http://wiki.nginx.org/HttpCoreModule#keepalive_requests
