### PR TITLE
Set connection.keep_alive_timeout using idle_timeout in ruby 2.0.

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -631,6 +631,7 @@ class Net::HTTP::Persistent
     start connection unless connection.started?
 
     connection.read_timeout = @read_timeout if @read_timeout
+    connection.keep_alive_timeout = @idle_timeout if @idle_timeout && connection.respond_to?(:keep_alive_timeout=)
 
     connection
   rescue Errno::ECONNREFUSED

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -274,6 +274,7 @@ class TestNetHttpPersistent < Minitest::Test
   def test_connection_for
     @http.open_timeout = 123
     @http.read_timeout = 321
+    @http.idle_timeout = 42
     c = @http.connection_for @uri
 
     assert_kind_of @http_class, c
@@ -283,6 +284,7 @@ class TestNetHttpPersistent < Minitest::Test
 
     assert_equal 123, c.open_timeout
     assert_equal 321, c.read_timeout
+    assert_equal 42, c.keep_alive_timeout unless RUBY_1
 
     assert_includes conns[0].keys, 'example.com:80'
     assert_same c, conns[0]['example.com:80']


### PR DESCRIPTION
Fixes issue #39
## Problem

Ruby 2.0 added keep_alive_timeout, which behaves the same way as idle_timeout, except that the default timeout is 5 seconds rather than 2 seconds.  This means that the default timeout is effectively 2 seconds, and idle_timeout isn't respected when it is greater than 2 seconds.
## Solution

Set keep_alive_timeout on the connection using idle_timeout on ruby 2.0.
