### PR TITLE
fix: error with no-proxy

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -863,10 +863,10 @@ class Net::HTTP::Persistent
 
     @no_proxy.clear
 
-    @proxy_uri.user = unescape @proxy_uri.user
-    @proxy_uri.password = unescape @proxy_uri.password
-
     if @proxy_uri then
+      @proxy_uri.user = unescape @proxy_uri.user
+      @proxy_uri.password = unescape @proxy_uri.password
+
       @proxy_args = [
         @proxy_uri.host,
         @proxy_uri.port,


### PR DESCRIPTION
At `Net::HTTP::Persistent#proxy=` function:

when @agent.proxy = nil

```
     NoMethodError:
       undefined method `user' for nil:NilClass
```
