### PR TITLE
Do not set @proxy_uri attributes if nil

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -863,10 +863,10 @@ class Net::HTTP::Persistent
 
     @no_proxy.clear
 
-    @proxy_uri.user = unescape @proxy_uri.user
-    @proxy_uri.password = unescape @proxy_uri.password
-
     if @proxy_uri then
+      @proxy_uri.user = unescape @proxy_uri.user
+      @proxy_uri.password = unescape @proxy_uri.password
+      
       @proxy_args = [
         @proxy_uri.host,
         @proxy_uri.port,


### PR DESCRIPTION
With Mechanize (2.7.2) and net-http-persistent (2.9.2) when running:

```
 >> Mechanize.new
```

I get the following exception:

```
NoMethodError: undefined method `user' for nil:NilClass
    from /Users/kenny/.rvm/gems/ruby-1.9.3-head@riffle/gems/net-http-persistent-2.9.2/lib/net/http/persistent.rb:866:in `proxy='
    from /Users/kenny/.rvm/gems/ruby-1.9.3-head@riffle/gems/mechanize-2.7.2/lib/mechanize/http/agent.rb:1189:in `set_proxy'
    from /Users/kenny/.rvm/gems/ruby-1.9.3-head@riffle/gems/mechanize-2.7.2/lib/mechanize.rb:204:in `initialize'
    from (irb):1:in `new'
    from (irb):1
    from /Users/kenny/.rvm/gems/ruby-1.9.3-head@riffle/gems/railties-3.2.16/lib/rails/commands/console.rb:47:in `start'
    from /Users/kenny/.rvm/gems/ruby-1.9.3-head@riffle/gems/railties-3.2.16/lib/rails/commands/console.rb:8:in `start'
    from /Users/kenny/.rvm/gems/ruby-1.9.3-head@riffle/gems/railties-3.2.16/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```

The following patch fixes that.
