### PR TITLE
Actually fix unescaping of proxy auth credentials

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -864,14 +864,11 @@ class Net::HTTP::Persistent
     @no_proxy.clear
 
     if @proxy_uri then
-      @proxy_uri.user = unescape @proxy_uri.user
-      @proxy_uri.password = unescape @proxy_uri.password
-
       @proxy_args = [
         @proxy_uri.host,
         @proxy_uri.port,
-        @proxy_uri.user,
-        @proxy_uri.password,
+        unescape(@proxy_uri.user),
+        unescape(@proxy_uri.password),
       ]
 
       @proxy_connection_id = [nil, *@proxy_args].join ':'

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -507,13 +507,15 @@ class TestNetHttpPersistent < Minitest::Test
 
   def test_connection_for_proxy_unescaped
     uri = URI.parse 'http://proxy.example'
-    uri.user     = 'john%24doe'
-    uri.password = 'muf%24fins'
+    uri.user = 'john%40doe'
+    uri.password = 'muf%3Afins'
+    uri.freeze
 
     http = Net::HTTP::Persistent.new nil, uri
+    c = http.connection_for @uri
 
-    assert_equal 'john$doe', http.proxy_uri.user
-    assert_equal 'muf$fins', http.proxy_uri.password
+    assert_includes conns[1].keys,
+                    'example.com:80:proxy.example:80:john@doe:muf:fins'
   end
 
   def test_connection_for_proxy_host_down


### PR DESCRIPTION
- The current way is broken as it chokes while unescaping characters that are not allowed non-escaped in the userinfo URI component, such as "@" if the username is an email address.
- Being a nice Ruby citizen means not mutating the `@proxy_uri` which is an object that might have came from the user.

References #54 #56. Fixes #48

/cc @juhakaja @tumf
