### PR TITLE
avoid auto proxy detection when no_proxy is set

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -616,6 +616,8 @@ class Net::HTTP::Persistent
     if @proxy_uri and not proxy_bypass? uri.host, uri.port then
       connection_id << @proxy_connection_id
       net_http_args.concat @proxy_args
+    elsif proxy_bypass? uri.host, uri.port then
+      net_http_args.concat [nil]
     end
 
     connection = connections[connection_id]

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -940,7 +940,7 @@ class TestNetHttpPersistent < Minitest::Test
 
     assert c.started?
     refute c.proxy?
-    refute c.proxy_from_env?
+    refute c.proxy_from_env? unless RUBY_1
   end
 
   def test_reconnect

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -928,6 +928,21 @@ class TestNetHttpPersistent < Minitest::Test
     refute @http.proxy_bypass? 'example.org', 80
   end
 
+  def test_connection_for_no_proxy_from_env
+    ENV['http_proxy'] = 'proxy.example'
+    ENV['no_proxy'] = 'localhost, example.com,'
+    ENV['proxy_user'] = 'johndoe'
+    ENV['proxy_password'] = 'muffins'
+
+    http = Net::HTTP::Persistent.new nil, :ENV
+
+    c = http.connection_for @uri
+
+    assert c.started?
+    refute c.proxy?
+    refute c.proxy_from_env?
+  end
+
   def test_reconnect
     result = @http.reconnect
 


### PR DESCRIPTION
Net::HTTP use environment variables for proxy when the 3rd argument of ::new.
In this case, proxy server is used even if the host name is included in NO_PROXY.
