### PR TITLE
limiting bindings of default_proc

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -277,6 +277,16 @@ class Net::HTTP::Persistent
   end
 
   ##
+  # Returns a new nested hash
+  #
+  # Using a class method to limit the bindings referenced by the
+  # hash's default_proc
+
+  def self.new_nested_hash
+    Hash.new { |h,k| h[k] = {} }
+  end
+
+  ##
   # This client's OpenSSL::X509::Certificate
 
   attr_reader :certificate
@@ -586,8 +596,8 @@ class Net::HTTP::Persistent
   # Creates a new connection for +uri+
 
   def connection_for uri
-    Thread.current[@generation_key]     ||= Hash.new { |h,k| h[k] = {} }
-    Thread.current[@ssl_generation_key] ||= Hash.new { |h,k| h[k] = {} }
+    Thread.current[@generation_key]     ||= Net::HTTP::Persistent.new_nested_hash
+    Thread.current[@ssl_generation_key] ||= Net::HTTP::Persistent.new_nested_hash
     Thread.current[@request_key]        ||= Hash.new 0
     Thread.current[@timeout_key]        ||= Hash.new EPOCH
 


### PR DESCRIPTION
Otherwise the hash’s default_proc will keep references to locals in 
method connection_for as well as the current instantiation of Net::HTTP:Persistent
