### PR TITLE
Use #respond_to? instead of === to determine URI-ness

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -1112,7 +1112,7 @@ class Net::HTTP::Persistent
   # Returns the request.
 
   def request_setup req_or_uri # :nodoc:
-    req = if URI === req_or_uri then
+    req = if req_or_uri.respond_to? 'request_uri' then
             Net::HTTP::Get.new req_or_uri.request_uri
           else
             req_or_uri


### PR DESCRIPTION
Persistent#request_setup has a check on the class of the value
req_or_uri which tests to see if req_or_uri is an instance of URI.
But there's a good chance that someone might pass an instance of
Addressable::URI instead of URI, which will fail this check.

Addressable::URI is basically a drop-in replacement for URI, so there's
no reason to care which of these objects are passed, just that it
responds to the #request_uri method. So, #respond_to? to the rescue!
