### PR TITLE
use URI#hostname instead of host to support bracket-escaped IPv6

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -642,7 +642,7 @@ class Net::HTTP::Persistent
 
     use_ssl = uri.scheme.downcase == 'https'
 
-    net_http_args = [uri.host, uri.port]
+    net_http_args = [uri.hostname, uri.port]
 
     net_http_args.concat @proxy_args if
       @proxy_uri and not proxy_bypass? uri.host, uri.port


### PR DESCRIPTION
It should be possible to use URL with bracket escaped IPv6 address, like

``` ruby
u = URI(“http://[::1]/bar”) p u.hostname #=> “::1” p u.host #=> “[::1]”
```
