### PR TITLE
Use method to check idempotence in Net::HTTP::Persistent#idempotent?

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -721,9 +721,8 @@ class Net::HTTP::Persistent
   # Is +req+ idempotent according to RFC 2616?
 
   def idempotent? req
-    case req
-    when Net::HTTP::Delete, Net::HTTP::Get, Net::HTTP::Head,
-         Net::HTTP::Options, Net::HTTP::Put, Net::HTTP::Trace then
+    case req.method
+    when 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PUT', 'TRACE' then
       true
     end
   end
@@ -911,7 +910,7 @@ class Net::HTTP::Persistent
   # If a block is passed #request behaves like Net::HTTP#request (the body of
   # the response will not have been read).
   #
-  # +req+ must be a Net::HTTPRequest subclass (see Net::HTTP for a list).
+  # +req+ must be a Net::HTTPGenericRequest subclass (see Net::HTTP for a list).
   #
   # If there is an error and the request is idempotent according to RFC 2616
   # it will be retried automatically.

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -728,7 +728,16 @@ class TestNetHttpPersistent < Minitest::Test
     assert @http.idempotent? Net::HTTP::Put.new '/'
     assert @http.idempotent? Net::HTTP::Trace.new '/'
 
+    assert @http.idempotent? Net::HTTPGenericRequest.new('DELETE', false, true, '/')
+    assert @http.idempotent? Net::HTTPGenericRequest.new('GET', false, true, '/')
+    assert @http.idempotent? Net::HTTPGenericRequest.new('HEAD', false, false, '/')
+    assert @http.idempotent? Net::HTTPGenericRequest.new('OPTIONS', false, false, '/')
+    assert @http.idempotent? Net::HTTPGenericRequest.new('PUT', true, true, '/')
+    assert @http.idempotent? Net::HTTPGenericRequest.new('TRACE', false, true, '/')
+
     refute @http.idempotent? Net::HTTP::Post.new '/'
+
+    refute @http.idempotent? Net::HTTPGenericRequest.new('POST', true, true, '/')
   end
 
   def test_normalize_uri


### PR DESCRIPTION
Right now `faraday` is passing in an instance of `Net::HTTPGenericRequest` and the `idempotent?` check fails, even though some requests are idempotent based on the actual method.

I believe it's better to check the actual method instead of the class hierarchy.

For a more thorough description of the problem have a look at lostisland/faraday#647.