### PR TITLE
Fix doc example for Net::HTTP::Persistent.new

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -32,7 +32,7 @@ connection is kept alive between requests:
 
     uri = URI 'http://example.com/awesome/web/service'
 
-    http = Net::HTTP::Persistent.new 'my_app_name'
+    http = Net::HTTP::Persistent.new name: 'my_app_name'
 
     # perform a GET
     response = http.request uri


### PR DESCRIPTION
- Since 3.0 it now expects named parameters

Since upgrading from 2.x I was hitting a similar issue to https://github.com/drbrain/net-http-persistent/issues/80