### PR TITLE
Update initializer docs to use kwargs for `name`

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -32,7 +32,7 @@ connection is kept alive between requests:
 
     uri = URI 'http://example.com/awesome/web/service'
 
-    http = Net::HTTP::Persistent.new 'my_app_name'
+    http = Net::HTTP::Persistent.new name: 'my_app_name'
 
     # perform a GET
     response = http.request uri

--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -33,7 +33,7 @@ autoload :OpenSSL, 'openssl'
 #
 #   uri = URI 'http://example.com/awesome/web/service'
 #
-#   http = Net::HTTP::Persistent.new 'my_app_name'
+#   http = Net::HTTP::Persistent.new name: 'my_app_name'
 #
 #   # perform a GET
 #   response = http.request uri
@@ -153,7 +153,7 @@ autoload :OpenSSL, 'openssl'
 #   uri = URI 'http://example.com/awesome/web/service'
 #   post_uri = uri + 'create'
 #
-#   http = Net::HTTP::Persistent.new 'my_app_name'
+#   http = Net::HTTP::Persistent.new name: 'my_app_name'
 #
 #   post = Net::HTTP::Post.new post_uri.path
 #   # ... fill in POST request


### PR DESCRIPTION
This is a more exhaustive version of https://github.com/drbrain/net-http-persistent/pull/84, which only updated the docs in one place.

Version 3.0 introduced kwargs to the initializer in this commit: 5d4b76c22dd38d29b6fbc1ed700a2a1c78c5abc4

Aside from updating the written docs (_i.e._, this PR), the docs need to be regenerated/republished anyway to update the method signature — right now, the docs for `Net::HTTP::Persistent::new` have an out-of-date signature of `new(name = nil, proxy = nil)`.  Simply regenerating the docs even without these changes updates the signature to the correct `new(name: nil, proxy: nil, pool_size: DEFAULT_POOL_SIZE)`.

* Fixes https://github.com/drbrain/net-http-persistent/issues/80
* Probably fixes https://github.com/drbrain/net-http-persistent/issues/81