### PR TITLE
Add explicit nil proxy arguments - Corrects no_proxy support

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -607,8 +607,11 @@ class Net::HTTP::Persistent
 
     net_http_args = [uri.host, uri.port]
 
-    net_http_args.concat @proxy_args if
-      @proxy_uri and not proxy_bypass? uri.host, uri.port
+    if @proxy_uri and not proxy_bypass? uri.host, uri.port then
+      net_http_args.concat @proxy_args
+    else
+      net_http_args.concat [nil, nil, nil, nil]
+    end
 
     connection = @pool.checkout net_http_args
 

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -120,7 +120,7 @@ class TestNetHttpPersistent < Minitest::Test
   def basic_connection
     raise "#{@uri} is not HTTP" unless @uri.scheme.downcase == 'http'
 
-    net_http_args = [@uri.host, @uri.port]
+    net_http_args = [@uri.host, @uri.port, nil, nil, nil, nil]
 
     connection = Net::HTTP::Persistent::Connection.allocate
     connection.ssl_generation = @http.ssl_generation
@@ -152,7 +152,7 @@ class TestNetHttpPersistent < Minitest::Test
   def ssl_connection
     raise "#{@uri} is not HTTPS" unless @uri.scheme.downcase == 'https'
 
-    net_http_args = [@uri.host, @uri.port]
+    net_http_args = [@uri.host, @uri.port, nil, nil, nil, nil]
 
     connection = Net::HTTP::Persistent::Connection.allocate
     connection.ssl_generation = @http.ssl_generation
@@ -279,7 +279,7 @@ class TestNetHttpPersistent < Minitest::Test
       c
     end
 
-    stored = @http.pool.checkout ['example.com', 80]
+    stored = @http.pool.checkout ['example.com', 80, nil, nil, nil, nil]
 
     assert_same used, stored
   end


### PR DESCRIPTION
Currently, when a hostname matches a value contained within the `no_proxy` environment variable, no proxy value is added to the net_http_args which ultimately get passed to `Net::HTTP.new()`.

When this occurs and explicit nil values are not passed, `Net::HTTP` will fall back to the `http_proxy` and `https_proxy` environment variables thus ignoring `no_proxy` so the request will traverse the proxy erroneously.

https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#method-c-new