### PR TITLE
Allow setting min/max SSL version for a connection on Ruby 2.5

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -440,9 +440,25 @@ class Net::HTTP::Persistent
   # SSL version to use.
   #
   # By default, the version will be negotiated automatically between client
-  # and server.  Ruby 1.9 and newer only.
+  # and server.  Ruby 1.9 and newer only. Deprecated since Ruby 2.5.
 
   attr_reader :ssl_version
+
+  ##
+  # Minimum SSL version to use, e.g. :TLS1_1
+  #
+  # By default, the version will be negotiated automatically between client
+  # and server.  Ruby 2.5 and newer only.
+
+  attr_reader :min_version
+
+  ##
+  # Maximum SSL version to use, e.g. :TLS1_2
+  #
+  # By default, the version will be negotiated automatically between client
+  # and server.  Ruby 2.5 and newer only.
+
+  attr_reader :max_version
 
   ##
   # Where this instance's last-use times live in the thread local variables
@@ -533,6 +549,8 @@ class Net::HTTP::Persistent
     @private_key        = nil
     @ssl_timeout        = nil
     @ssl_version        = nil
+    @min_version        = nil
+    @max_version        = nil
     @verify_callback    = nil
     @verify_depth       = nil
     @verify_mode        = nil
@@ -1044,6 +1062,8 @@ class Net::HTTP::Persistent
     connection.ciphers     = @ciphers     if @ciphers
     connection.ssl_timeout = @ssl_timeout if @ssl_timeout
     connection.ssl_version = @ssl_version if @ssl_version
+    connection.min_version = @min_version if @min_version
+    connection.max_version = @max_version if @max_version
 
     connection.verify_depth = @verify_depth
     connection.verify_mode  = @verify_mode
@@ -1111,6 +1131,24 @@ application:
 
   def ssl_version= ssl_version
     @ssl_version = ssl_version
+
+    reconnect_ssl
+  end
+
+  ##
+  # Minimum SSL version to use
+
+  def min_version= min_version
+    @min_version = min_version
+
+    reconnect_ssl
+  end
+
+  ##
+  # maximum SSL version to use
+
+  def max_version= max_version
+    @max_version = max_version
 
     reconnect_ssl
   end

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -77,8 +77,8 @@ class TestNetHttpPersistent < Minitest::Test
   class BasicConnection
     attr_accessor :started, :finished, :address, :port, :use_ssl,
                   :read_timeout, :open_timeout, :keep_alive_timeout
-    attr_accessor :ciphers, :ssl_timeout, :ssl_version,
-                  :verify_depth, :verify_mode, :cert_store,
+    attr_accessor :ciphers, :ssl_timeout, :ssl_version, :min_version,
+                  :max_version, :verify_depth, :verify_mode, :cert_store,
                   :ca_file, :ca_path, :cert, :key
     attr_reader :req, :debug_output
     def initialize
@@ -1524,6 +1524,20 @@ class TestNetHttpPersistent < Minitest::Test
     @http.ssl_version = :ssl_version
 
     assert_equal :ssl_version, @http.ssl_version
+    assert_equal 1, @http.ssl_generation
+  end
+
+  def test_min_version_equals
+    @http.min_version = :min_version
+
+    assert_equal :min_version, @http.min_version
+    assert_equal 1, @http.ssl_generation
+  end
+
+  def test_max_version_equals
+    @http.max_version = :max_version
+
+    assert_equal :max_version, @http.max_version
     assert_equal 1, @http.ssl_generation
   end
 


### PR DESCRIPTION
The functionality in the OpenSSL gem was introduced in ruby/openssl#142 and supported by Net::HTTP in Ruby 2.5: https://github.com/ruby/ruby/commit/dcea9198a9d80bdf4eeacd9d9e9d883850a4a8d2

An example why this might be useful; for payment data the PCI DSS [mandates](https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls) that TLS 1.1 or newer is used after June 30. Using `ssl_version` would disallow the client negotiating TLS 1.2 (or 1.3 in the near future) if both sides support it, `min_version` doesn't have this problem.