### PR TITLE
Fix exception message to not guess whether proxy was used

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -633,11 +633,8 @@ class Net::HTTP::Persistent
     port    = http.proxy_port    || http.port
 
     raise Error, "connection refused: #{address}:#{port}"
-  rescue Errno::EHOSTDOWN
-    address = http.proxy_address || http.address
-    port    = http.proxy_port    || http.port
-
-    raise Error, "host down: #{address}:#{port}"
+  rescue Errno::EHOSTDOWN => e
+    raise Error, e.message
   ensure
     @pool.checkin net_http_args
   end


### PR DESCRIPTION
Fix exception message to not guess whether proxy or real port (or address) was tried (and failed) by net/http.

The actual determination of whether a proxy was tried is here:
https://github.com/ruby/ruby/blob/3471d0f6d6619b41b7054bd7bb87e929156abde2/lib/net/http.rb#L1079-L1081

There's no need to reproduce the logic of net/http. We can instead just pass the error message through.


In my case, I am having an issue with bundler. I haven't figured it out yet, but this error message was misleading. Here's the exception returned from Net::HTTP:
```
#<Errno::EHOSTDOWN: Host is down - connect(2) for "gems.contribsys.com" port 443>
```

Then net-http-persistent rescued that, and raised it like this:
```
Bundler::Persistent::Net::HTTP::Persistent::Error: host down: gems.contribsys.com:80
```

That port=80 is incorrect. This PR allows the original message to pass through.