### PR TITLE
update .travis.yml with latest non-EOL rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ notifications:
   email:
   - drbrain@segment7.net
 rvm:
-- 2.1.10
-- 2.2.5
-- 2.3.1
+- 2.3.8
+- 2.4.5
+- 2.5.3
+- 2.6.0-rc1
 script: rake travis


### PR DESCRIPTION
This updates the ruby versions that we target in CI to the non-EOL versions. Happy to remove 2.6.0-rc1 if you'd prefer not to build with the release candidate.