### PR TITLE
fix memory leak introduced by connection pooling

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -1048,9 +1048,7 @@ class Net::HTTP::Persistent
   # #shutdown when you are completely done making requests!
 
   def shutdown
-    @pool.available.shutdown do |http|
-      http.finish
-    end
+    @pool.shutdown { |http| http.finish }
   end
 
   ##


### PR DESCRIPTION
5bae22e8a3626ab3b14743c00796d4f176580ad8 introduced a memory leak when
it switched to connection pooling.  We're setting a thread local but
then never clearing the local.  If the pool is used in the main thread,
it will never die and the locals will stick around for the life of the
process.

Here is the program I used to test:

```
require 'net/http/persistent'

def run2
  1000.times do
    uri = URI 'http://localhost:5000'
    http = Net::HTTP::Persistent.new name: 'my_app_name'
    # perform a GET
    response = http.request uri
    # if you are done making http requests, or won't make requests for several
    # minutes
    http.shutdown
  end
end

p Thread.current.keys
run2
p Thread.current.keys
```