### PR TITLE
adds ruby 2.6 write_timeout support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /TAGS
 /doc
 /pkg
+.idea

--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -407,6 +407,11 @@ class Net::HTTP::Persistent
   attr_accessor :read_timeout
 
   ##
+  # Seconds to wait until writing one block.  See Net::HTTP#write_timeout
+
+  attr_accessor :write_timeout
+
+  ##
   # By default SSL sessions are reused to avoid extra SSL handshakes.  Set
   # this to false if you have problems communicating with an HTTPS server
   # like:
@@ -530,6 +535,7 @@ class Net::HTTP::Persistent
     @keep_alive       = 30
     @open_timeout     = nil
     @read_timeout     = nil
+    @write_timeout    = nil
     @idle_timeout     = 5
     @max_requests     = nil
     @socket_options   = []
@@ -643,6 +649,7 @@ class Net::HTTP::Persistent
     end
 
     http.read_timeout = @read_timeout if @read_timeout
+    http.write_timeout = @write_timeout if @write_timeout && http.respond_to?(:write_timeout=)
     http.keep_alive_timeout = @idle_timeout if @idle_timeout
 
     return yield connection


### PR DESCRIPTION
Ruby 2.6 [adds a new option `write_timeout`](https://blog.bigbinary.com/2018/08/14/ruby-2-6-adds-write-timeout-to-net-http.html) to `net::http`. This PR exposes it in `net-http-persistent`.

Kudos to @tenderlove since he basically wrote the diff. I added the guard to make sure it does not break in case client is not running >= 2.6