### PR TITLE
stop shipping files end-users do not need

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,13 +1,6 @@
-.autotest
-.gemtest
-.travis.yml
 History.txt
-Manifest.txt
 README.rdoc
-Rakefile
 lib/net/http/persistent.rb
 lib/net/http/persistent/connection.rb
 lib/net/http/persistent/pool.rb
 lib/net/http/persistent/timed_stack_multi.rb
-test/test_net_http_persistent.rb
-test/test_net_http_persistent_timed_stack_multi.rb


### PR DESCRIPTION
more of a test-balloon PR for adding the Gemfile, because that made rake fail too ... how do you suggest fixing the test failure ? @drbrain 

```
--- Manifest.txt	2019-05-07 01:13:22.747033068 +0000
+++ Manifest.tmp	2019-05-07 01:13:55.529703866 +0000
@@ -1,6 +1,13 @@
+.autotest
+.gemtest
+.travis.yml
```