### PR TITLE
Clear thread data in the "checkin" method to fix memory leak

### DIFF
--- a/lib/net/http/persistent/pool.rb
+++ b/lib/net/http/persistent/pool.rb
@@ -20,6 +20,9 @@ class Net::HTTP::Persistent::Pool < ConnectionPool # :nodoc:
 
     if stack.empty?
       @available.push conn, connection_args: net_http_args
+
+      Thread.current[@key].delete(net_http_args)
+      Thread.current[@key] = nil if Thread.current[@key].empty?
     end
 
     nil


### PR DESCRIPTION
Still leaking memory when [using with Faraday](https://github.com/lostisland/faraday/blob/master/docs/adapters/net_http_persistent.md). Since the `shutdown` method added in https://github.com/drbrain/net-http-persistent/pull/98 cannot be called from the Faraday adapter, empty arrays remain in the main thread after making requests:
```ruby
Thread.current.keys
#=> [.., :"current-70179311374800", ..]
Thread.current[:"current-70179311374800"]
#=> {["example.org", 443]=>[]}
```

In the [connection_pool gem](https://github.com/mperham/connection_pool), thread data is set to `nil` in the [`checkin` method](https://github.com/mperham/connection_pool/blob/v2.2.2/lib/connection_pool.rb#L101):
```ruby
  def checkin
    if ::Thread.current[@key]
      if ::Thread.current[@key_count] == 1
        @available.push(::Thread.current[@key])
        ::Thread.current[@key]= nil
      else
        ::Thread.current[@key_count]-= 1
      end
    else
      raise ConnectionPool::Error, 'no connections are checked out'
    end

    nil
  end
```

This PR is following the logic to clear thread data in the `checkin` method.

@tenderlove It seems the [change bumping the version to `3.0.1`](https://github.com/drbrain/net-http-persistent/commit/b06a2f71cb0b912bcc2a37b00f54ee34683fe649) is not merged into the master branch. How should I bump the version?

@jcarres-mdsol @jfeltesse-mdsol @cabbott @ssteeg-mdsol @piao-mdsol 