### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -1195,6 +1195,6 @@ application:
 
 end
 
-require 'net/http/persistent/connection'
-require 'net/http/persistent/pool'
+require_relative 'persistent/connection'
+require_relative 'persistent/pool'
 

--- a/lib/net/http/persistent/pool.rb
+++ b/lib/net/http/persistent/pool.rb
@@ -46,5 +46,5 @@ class Net::HTTP::Persistent::Pool < ConnectionPool # :nodoc:
   end
 end
 
-require 'net/http/persistent/timed_stack_multi'
+require_relative 'timed_stack_multi'
 


### PR DESCRIPTION
I'd like to use `require_relative` for internal requires, because it's faster since it doesn't use the LOAD_PATH, and it's also more readable.

This is more critical for bundler (that vendors this gem) because given the LOAD_PATH manipulations bundler does, and that a default copy of bundler is always in the LOAD_PATH in the latest rubies, `require_relative` is safer.