### PR TITLE
Revert "Sets a default pool size for Windows as Process::RLIMIT_NOFIL…

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -202,10 +202,10 @@ class Net::HTTP::Persistent
   ##
   # The default connection pool size is 1/4 the allowed open files.
 
-  if Gem.win_platform? then
-    DEFAULT_POOL_SIZE = 256
-  else
+  if Process.const_defined? :RLIMIT_NOFILE
     DEFAULT_POOL_SIZE = Process.getrlimit(Process::RLIMIT_NOFILE).first / 4
+  else
+    DEFAULT_POOL_SIZE = 256
   end
 
   ##


### PR DESCRIPTION
…E is not supported"

This reverts commit 60784a16a1ecf0f9a2b02dbe7c55a7f40de08993, because this commit introduces unexpected dependency on RubyGems. There is likely better way to detect support for `Process::RLIMIT_NOFILE`.

@BrianPurgert, @jakauppila could you please explain what was the error message and find better way to fall back?