### PR TITLE
Fix link to wrong PR

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -23,7 +23,7 @@ Bug fixes:
   Kauppila.
 * Fix missing +name:+ argument in documentation.  Pull requests #85 by T.J.
   Schuck, #84 by James White.
-* Fix memory leak from connection pooling.  Pull request #97 by Aaron
+* Fix memory leak from connection pooling.  Pull request #98 by Aaron
   Patterson.
 * Update tests for minitest assert_equal deprecation.  Pull request #92 by
   Olle Jonsson.


### PR DESCRIPTION
Noticed that Aaron's PR was https://github.com/drbrain/net-http-persistent/pull/98, and not https://github.com/drbrain/net-http-persistent/pull/97.

I think the GH release page might need to be updated as well:
https://github.com/drbrain/net-http-persistent/releases/tag/v3.1.0