### PR TITLE
Fix double-connect bug after exceeding idle_timeout

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -738,6 +738,7 @@ class Net::HTTP::Persistent
   def finish connection
     connection.finish
 
+    connection.http.instance_variable_set :@last_communicated, nil
     connection.http.instance_variable_set :@ssl_session, nil unless
       @reuse_ssl_sessions
   end

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -698,6 +698,7 @@ class TestNetHttpPersistent < Minitest::Test
   def test_finish
     c = basic_connection
     c.requests = 5
+    c.http.instance_variable_set(:@last_communicated, Process.clock_gettime(Process::CLOCK_MONOTONIC))
 
     @http.finish c
 
@@ -706,6 +707,7 @@ class TestNetHttpPersistent < Minitest::Test
 
     assert_equal 0, c.requests
     assert_equal Net::HTTP::Persistent::EPOCH, c.last_use
+    assert_equal nil, c.http.instance_variable_get(:@last_communicated)
   end
 
   def test_finish_io_error


### PR DESCRIPTION
Previously, when keep_alive_timeout <= idle_timeout, and a request
arrives after exceeding idle_timeout, the following will be called:
- Net::HTTP::Persistent#request
  - Net::HTTP::Persistent#reset
    - Net::HTTP#finish
    - Net::HTTP#start
      - Net::HTTP#connect
  - Net::HTTP#request
    - Net::HTTP#begin_transport
      - Socket#close, 'Conn close because of keep_alive_timeout'
      - Net::HTTP#connect

As connect is called twice, a perfectly good connection is wasted.

Commit 1dcdf06f fixed the case when a request arrives before exceeding
idle_timeout, but the above edge case remains.

Fix it by resetting the "last_communicated" value back to nil after
calling Net::HTTP#finish.