### PR TITLE
Handle Net::HTTP#verify_hostname in SSL Context if available

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -981,8 +981,8 @@ class Net::HTTP::Persistent
     connection.min_version = @min_version if @min_version
     connection.max_version = @max_version if @max_version
 
-    connection.verify_depth = @verify_depth
-    connection.verify_mode  = @verify_mode
+    connection.verify_depth    = @verify_depth
+    connection.verify_mode     = @verify_mode
     connection.verify_hostname = @verify_hostname if
       @verify_hostname && connection.respond_to?(:verify_hostname=)
 

--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -460,7 +460,7 @@ class Net::HTTP::Persistent
   # You can set +verify_hostname+ as true to use hostname verification
   # during the handshake.
   #
-  # NOTE: This may work with Ruby > 2.8.
+  # NOTE: This works with Ruby > 3.0.
 
   attr_reader :verify_hostname
 

--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -73,6 +73,8 @@ autoload :OpenSSL, 'openssl'
 # #verify_callback    :: For server certificate verification
 # #verify_depth       :: Depth of certificate verification
 # #verify_mode        :: How connections should be verified
+# #verify_hostname    :: Use hostname verification for server certificate
+#                        during the handshake
 #
 # == Proxies
 #
@@ -448,6 +450,21 @@ class Net::HTTP::Persistent
   attr_reader :verify_mode
 
   ##
+  # HTTPS verify_hostname.
+  #
+  # If a client sets this to true and enables SNI with SSLSocket#hostname=,
+  # the hostname verification on the server certificate is performed
+  # automatically during the handshake using
+  # OpenSSL::SSL.verify_certificate_identity().
+  #
+  # You can set +verify_hostname+ as true to use hostname verification
+  # during the handshake.
+  #
+  # NOTE: This may work with Ruby > 2.8.
+
+  attr_reader :verify_hostname
+
+  ##
   # Creates a new Net::HTTP::Persistent.
   #
   # Set a +name+ for fun.  Your library name should be good enough, but this
@@ -506,6 +523,7 @@ class Net::HTTP::Persistent
     @verify_callback    = nil
     @verify_depth       = nil
     @verify_mode        = nil
+    @verify_hostname    = nil
     @cert_store         = nil
 
     @generation         = 0 # incremented when proxy URI changes
@@ -965,6 +983,8 @@ class Net::HTTP::Persistent
 
     connection.verify_depth = @verify_depth
     connection.verify_mode  = @verify_mode
+    connection.verify_hostname = @verify_hostname if
+      @verify_hostname && connection.respond_to?(:verify_hostname=)
 
     if OpenSSL::SSL::VERIFY_PEER == OpenSSL::SSL::VERIFY_NONE and
        not Object.const_defined?(:I_KNOW_THAT_OPENSSL_VERIFY_PEER_EQUALS_VERIFY_NONE_IS_WRONG) then
@@ -1069,6 +1089,15 @@ application:
 
   def verify_mode= verify_mode
     @verify_mode = verify_mode
+
+    reconnect_ssl
+  end
+
+  ##
+  # Sets the HTTPS verify_hostname.  Defaults to false.
+
+  def verify_hostname= verify_hostname
+    @verify_hostname = verify_hostname
 
     reconnect_ssl
   end

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -1249,6 +1249,7 @@ class TestNetHttpPersistent < Minitest::Test
     assert_equal OpenSSL::SSL::VERIFY_PEER, c.verify_mode
     assert_kind_of OpenSSL::X509::Store,    c.cert_store
     assert_nil c.verify_callback
+    assert_nil c.verify_hostname if c.respond_to?(:verify_hostname)
   end
 
   def test_ssl_ca_file
@@ -1330,6 +1331,21 @@ class TestNetHttpPersistent < Minitest::Test
 
     assert c.use_ssl?
     assert_equal OpenSSL::SSL::VERIFY_NONE, c.verify_mode
+  end
+
+  def test_ssl_verify_hostname
+    skip 'OpenSSL is missing' unless HAVE_OPENSSL
+
+    @http.verify_hostname = true
+    c = Net::HTTP.new 'localhost', 80
+
+    skip 'net/http doesn\'t provide verify_hostname= method' unless
+      c.respond_to?(:verify_hostname=)
+
+    @http.ssl c
+
+    assert c.use_ssl?
+    assert c.verify_hostname
   end
 
   def test_ssl_warning


### PR DESCRIPTION
`Handle Net::HTTP#verify_hostname` was added in Ruby 3.0 or later.
I think that net/http/persistent should be thin wrapper, so, we should handle `Handle Net::HTTP#verify_hostname` in this gem.
This option can work with Ruby 3.0 or later.

WDYT?

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>