### PR TITLE
Update ruby_version requirement to allow ruby 3.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ Hoe.spec 'net-http-persistent' do
   self.readme_file      = 'README.rdoc'
   self.extra_rdoc_files += Dir['*.rdoc']
 
-  self.require_ruby_version '~> 2.3'
+  self.require_ruby_version '>= 2.3'
 
   license 'MIT'
 


### PR DESCRIPTION
Ruby master branch recently bumped the version number to 3.0: https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11

This is breaking our ruby-head CI.

cc @drbrain @tenderlove 