### PR TITLE
Handle timeout due to pool exhaustion

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,9 @@
+=== 4.0.6 / 2024-12-04
+
+Bug fixes:
+
+* Allow ConnectionPool exceptions from checkout to bubble up to caller.
+
 === 4.0.5 / 2024-12-04
 
 Bug fixes:

--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -181,7 +181,7 @@ class Net::HTTP::Persistent
   ##
   # The version of Net::HTTP::Persistent you are using
 
-  VERSION = '4.0.5'
+  VERSION = '4.0.6'
 
   ##
   # Error class for errors raised by Net::HTTP::Persistent.  Various

--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -630,47 +630,49 @@ class Net::HTTP::Persistent
 
     connection = @pool.checkout net_http_args
 
-    http = connection.http
+    begin
+      http = connection.http
 
-    connection.ressl @ssl_generation if
-      connection.ssl_generation != @ssl_generation
+      connection.ressl @ssl_generation if
+        connection.ssl_generation != @ssl_generation
 
-    if not http.started? then
-      ssl   http if use_ssl
-      start http
-    elsif expired? connection then
-      reset connection
+      if not http.started? then
+        ssl   http if use_ssl
+        start http
+      elsif expired? connection then
+        reset connection
+      end
+
+      http.keep_alive_timeout = @idle_timeout  if @idle_timeout
+      http.max_retries        = @max_retries   if http.respond_to?(:max_retries=)
+      http.read_timeout       = @read_timeout  if @read_timeout
+      http.write_timeout      = @write_timeout if
+        @write_timeout && http.respond_to?(:write_timeout=)
+
+      return yield connection
+    rescue Errno::ECONNREFUSED
+      if http.proxy?
+        address = http.proxy_address
+        port    = http.proxy_port
+      else
+        address = http.address
+        port    = http.port
+      end
+
+      raise Error, "connection refused: #{address}:#{port}"
+    rescue Errno::EHOSTDOWN
+      if http.proxy?
+        address = http.proxy_address
+        port    = http.proxy_port
+      else
+        address = http.address
+        port    = http.port
+      end
+
+      raise Error, "host down: #{address}:#{port}"
+    ensure
+      @pool.checkin net_http_args
     end
-
-    http.keep_alive_timeout = @idle_timeout  if @idle_timeout
-    http.max_retries        = @max_retries   if http.respond_to?(:max_retries=)
-    http.read_timeout       = @read_timeout  if @read_timeout
-    http.write_timeout      = @write_timeout if
-      @write_timeout && http.respond_to?(:write_timeout=)
-
-    return yield connection
-  rescue Errno::ECONNREFUSED
-    if http.proxy?
-      address = http.proxy_address
-      port    = http.proxy_port
-    else
-      address = http.address
-      port    = http.port
-    end
-
-    raise Error, "connection refused: #{address}:#{port}"
-  rescue Errno::EHOSTDOWN
-    if http.proxy?
-      address = http.proxy_address
-      port    = http.proxy_port
-    else
-      address = http.address
-      port    = http.port
-    end
-
-    raise Error, "host down: #{address}:#{port}"
-  ensure
-    @pool.checkin net_http_args
   end
 
   ##

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -280,6 +280,16 @@ class TestNetHttpPersistent < Minitest::Test
     assert_same used, stored
   end
 
+  def test_connection_for_exhaustion
+    @http = Net::HTTP::Persistent.new pool_size: 0
+
+    assert_raises Timeout::Error do
+      @http.connection_for @uri do |c|
+        assert_same nil, c
+      end
+    end
+  end
+
   def test_connection_for_cached
     cached = basic_connection
     cached.http.start


### PR DESCRIPTION
if the pool has no more available connections, it raises a timeout exception (ConnectionPool::TimeoutError which is a subclass of Timeout::Error)

however the `ensure` currently catches it and masks that exception with a `ConnectionPool::Error: no connections are checked out`

as far as I can tell, scoping the exception handling block a little tighter has no other impact than letting this exception through, so the consumer can actually detect the issue

any feedback/suggestions/alternatives welcome

cc @drbrain @tenderlove