### PR TITLE
Fix example in docs

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -37,7 +37,7 @@ autoload :OpenSSL, 'openssl'
 #   # or
 #
 #   get = Net::HTTP::Get.new uri.request_uri
-#   response = http.request get
+#   response = http.request uri, get
 #
 #   # create a POST
 #   post_uri = uri + 'create'


### PR DESCRIPTION
The docs give this snippet of code as an example of how to use the library.

```ruby
require 'net/http/persistent'

uri = URI 'http://example.com/awesome/web/service'

http = Net::HTTP::Persistent.new

# perform a GET
response = http.request uri

# or

get = Net::HTTP::Get.new uri.request_uri
response = http.request get

# create a POST
post_uri = uri + 'create'
post = Net::HTTP::Post.new post_uri.path
post.set_form_data 'some' => 'cool data'

# perform the POST, the URI is always required
response http.request post_uri, post
```

However this code doesn't actually run.

Shortening the example to just the problem area:
```ruby
require 'net/http/persistent'

uri = URI 'http://example.com/awesome/web/service'

http = Net::HTTP::Persistent.new

get = Net::HTTP::Get.new uri.request_uri
response = http.request get
```

gives

```
Traceback (most recent call last):
        2: from test.rb:8:in `<main>'
        1: from /foo/vendor/bundle/ruby/2.7.0/gems/net-http-persistent-4.0.1/lib/net/http/persistent.rb:881:in `request'
/usr/lib/ruby/2.7.0/uri/common.rb:739:in `URI': bad argument (expected URI object or URI string) (ArgumentError)
```

As the example doesn't pass the URI as the first argument.