### PR TITLE
Expose `ConnectionPool#reload`

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -947,7 +947,8 @@ class Net::HTTP::Persistent
   end
 
   ##
-  # Shuts down all connections
+  # Shuts down all connections. Attempting to checkout a connection after
+  # shutdown will raise an error.
   #
   # *NOTE*: Calling shutdown for can be dangerous!
   #
@@ -956,6 +957,17 @@ class Net::HTTP::Persistent
 
   def shutdown
     @pool.shutdown { |http| http.finish }
+  end
+
+  ##
+  # Discard all existing connections. Subsequent checkouts will create
+  # new connections as needed.
+  #
+  # If any thread is still using a connection it may cause an error!  Call
+  # #reload when you are completely done making requests!
+
+  def reload
+    @pool.reload { |http| http.finish }
   end
 
   ##

--- a/net-http-persistent.gemspec
+++ b/net-http-persistent.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.4".freeze
   s.summary = "Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts".freeze
 
-  s.add_runtime_dependency(%q<connection_pool>.freeze, ["~> 2.2"])
+  s.add_runtime_dependency(%q<connection_pool>.freeze, ["~> 2.2", ">= 2.2.4"])
 end
 

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -1244,6 +1244,17 @@ class TestNetHttpPersistent < Minitest::Test
     refute c2.http.finished?, 'present generation connection must not be finished'
   end
 
+  def test_reload
+    c = connection
+
+    @http.reload
+
+    c2 = connection
+
+    assert c.http.finished?, 'last-generation connection must be finished'
+    refute c2.http.finished?, 'present generation connection must not be finished'
+  end
+
   def test_ssl
     skip 'OpenSSL is missing' unless HAVE_OPENSSL
 

--- a/test/test_net_http_persistent_timed_stack_multi.rb
+++ b/test/test_net_http_persistent_timed_stack_multi.rb
@@ -57,7 +57,7 @@ class TestNetHttpPersistentTimedStackMulti < Minitest::Test
       @stack.pop timeout: 0
     end
 
-    assert_equal 'Waited 0 sec', e.message
+    assert_includes e.message, 'Waited 0 sec'
   end
 
   def test_pop_full


### PR DESCRIPTION
Ref: https://github.com/mperham/connection_pool/pull/140

When forking a process, you need to close existing connection to avoid sharing them across processes. `shutdown` does that, but it also mark the pool as no longer usable.

`connection_pool` `2.2.4` introduced `#reload` that discard existing connections, but let the pool be used again later. It's a much better fit for an `after_fork` callback.