### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.2]
-        os: [ubuntu-20.04, windows-2019]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, jruby-9.2]
+        os: [ubuntu-20.04, windows-2022]
         include:
           - { ruby: 3.1, os: ubuntu-20.04, matrix: pipeline }
 
@@ -23,13 +23,12 @@ jobs:
       CI_MATRIX: ${{ matrix.matrix }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        rubygems: 3.3.6
         bundler-cache: true
 
     - name: Test things

--- a/test/test_net_http_persistent_timed_stack_multi.rb
+++ b/test/test_net_http_persistent_timed_stack_multi.rb
@@ -57,7 +57,7 @@ class TestNetHttpPersistentTimedStackMulti < Minitest::Test
       @stack.pop timeout: 0
     end
 
-    assert_equal 'Waited 0 sec', e.message
+    assert_match 'Waited 0 sec', e.message
   end
 
   def test_pop_full


### PR DESCRIPTION
Also updates the checkout action version and Windows OS version.  I also removed the `rubygems` to the `setup-ruby` task can load the right bundler / rubygems version.

I need to switch the `assert_equal` to an `assert_match` because the message changed with recent updates.

Everything runs green on my fork.