### PR TITLE
Fix compatibility with `connection_pool 2.4+`

### DIFF
--- a/lib/net/http/persistent/connection.rb
+++ b/lib/net/http/persistent/connection.rb
@@ -25,6 +25,7 @@ class Net::HTTP::Persistent::Connection # :nodoc:
   ensure
     reset
   end
+  alias_method :close, :finish
 
   def reset
     @last_use = Net::HTTP::Persistent::EPOCH

--- a/lib/net/http/persistent/pool.rb
+++ b/lib/net/http/persistent/pool.rb
@@ -11,20 +11,32 @@ class Net::HTTP::Persistent::Pool < ConnectionPool # :nodoc:
   end
 
   def checkin net_http_args
-    stack = Thread.current[@key][net_http_args] ||= []
+    if net_http_args.is_a?(Hash) && net_http_args.size == 1 && net_http_args[:force]
+      # ConnectionPool 2.4+ calls `checkin(force: true)` after fork.
+      # When this happens, we should remove all connections from Thread.current
+      if stacks = Thread.current[@key]
+        stacks.each do |http_args, connections|
+          connections.each do |conn|
+            @available.push conn, connection_args: http_args
+          end
+          connections.clear
+        end
+      end
+    else
+      stack = Thread.current[@key][net_http_args] ||= []
 
-    raise ConnectionPool::Error, 'no connections are checked out' if
-      stack.empty?
+      raise ConnectionPool::Error, 'no connections are checked out' if
+        stack.empty?
 
-    conn = stack.pop
+      conn = stack.pop
 
-    if stack.empty?
-      @available.push conn, connection_args: net_http_args
+      if stack.empty?
+        @available.push conn, connection_args: net_http_args
 
-      Thread.current[@key].delete(net_http_args)
-      Thread.current[@key] = nil if Thread.current[@key].empty?
+        Thread.current[@key].delete(net_http_args)
+        Thread.current[@key] = nil if Thread.current[@key].empty?
+      end
     end
-
     nil
   end
 

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -1444,5 +1444,15 @@ class TestNetHttpPersistent < Minitest::Test
     assert_equal 1, @http.ssl_generation
   end
 
+  def test_connection_pool_after_fork
+    # ConnectionPool 2.4+ calls `checkin(force: true)` after fork
+    @http.pool.checkin(force: true)
+
+    @http.pool.checkout ['example.com', 80, nil, nil, nil, nil]
+    @http.pool.checkin(force: true)
+    @http.pool.reload do |connection|
+      connection.close
+    end
+  end
 end
 


### PR DESCRIPTION
Fix: https://github.com/mperham/connection_pool/issues/172
Ref: https://github.com/mperham/connection_pool/pull/166

ConnectionPool descendants must accept `checking(force: true)`.

When it's called, all the cached connection should be checked back in, and the `Thread.current` state reset.

Additionally, making `Connection` respond to `close` allow them to be automatically closed on fork.

@drbrain @tenderlove 