### PR TITLE
fix: update rdoc hosting domain

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,7 +1,7 @@
 = net-http-persistent
 
 home :: https://github.com/drbrain/net-http-persistent
-rdoc :: https://rdoc.info/gems/net-http-persistent
+rdoc :: https://rubydoc.info/gems/net-http-persistent
 
 == DESCRIPTION:
 


### PR DESCRIPTION
- update rdoc hosting domain.
- currently, too many redirect error occured.

https://github.com/drbrain/net-http-persistent/assets/15692588/accf336b-6f51-4dd1-8fc8-64c5128191b8

