### PR TITLE
Allow setting verify_hostname to false

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -1001,7 +1001,7 @@ class Net::HTTP::Persistent
     connection.verify_depth    = @verify_depth
     connection.verify_mode     = @verify_mode
     connection.verify_hostname = @verify_hostname if
-      @verify_hostname && connection.respond_to?(:verify_hostname=)
+      @verify_hostname != nil && connection.respond_to?(:verify_hostname=)
 
     if OpenSSL::SSL::VERIFY_PEER == OpenSSL::SSL::VERIFY_NONE and
        not Object.const_defined?(:I_KNOW_THAT_OPENSSL_VERIFY_PEER_EQUALS_VERIFY_NONE_IS_WRONG) then
@@ -1111,7 +1111,7 @@ application:
   end
 
   ##
-  # Sets the HTTPS verify_hostname.  Defaults to false.
+  # Sets the HTTPS verify_hostname.
 
   def verify_hostname= verify_hostname
     @verify_hostname = verify_hostname
@@ -1131,4 +1131,3 @@ end
 
 require_relative 'persistent/connection'
 require_relative 'persistent/pool'
-

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -1343,7 +1343,7 @@ class TestNetHttpPersistent < Minitest::Test
     assert_equal OpenSSL::SSL::VERIFY_NONE, c.verify_mode
   end
 
-  def test_ssl_verify_hostname
+  def test_ssl_enable_verify_hostname
     skip 'OpenSSL is missing' unless HAVE_OPENSSL
 
     @http.verify_hostname = true
@@ -1357,6 +1357,22 @@ class TestNetHttpPersistent < Minitest::Test
     assert c.use_ssl?
     assert c.verify_hostname
   end
+
+  def test_ssl_disable_verify_hostname
+    skip 'OpenSSL is missing' unless HAVE_OPENSSL
+
+    @http.verify_hostname = false
+    c = Net::HTTP.new 'localhost', 80
+
+    skip 'net/http doesn\'t provide verify_hostname= method' unless
+      c.respond_to?(:verify_hostname=)
+
+    @http.ssl c
+
+    assert c.use_ssl?
+    assert c.verify_hostname == false
+  end
+
 
   def test_ssl_warning
     skip 'OpenSSL is missing' unless HAVE_OPENSSL
@@ -1474,4 +1490,3 @@ class TestNetHttpPersistent < Minitest::Test
     end
   end
 end
-


### PR DESCRIPTION
Follow-up to https://github.com/drbrain/net-http-persistent/pull/120.

In that PR `verify_hostname` was added, but it cannot be set to `false` which its main function as a configurable option as per https://github.com/ruby/ruby/pull/2858.

> Add #verify_hostname= and #verify_hostname to skip hostname verification