### PR TITLE
Close discarded connections

### DIFF
--- a/lib/net/http/persistent/timed_stack_multi.rb
+++ b/lib/net/http/persistent/timed_stack_multi.rb
@@ -63,7 +63,8 @@ class Net::HTTP::Persistent::TimedStackMulti < ConnectionPool::TimedStack # :nod
     if @created >= @max && @enqueued >= 1
       oldest, = @lru.first
       @lru.delete oldest
-      @ques[oldest].pop
+      connection = @ques[oldest].pop
+      connection.close if connection.respond_to?(:close)
 
       @created -= 1
     end


### PR DESCRIPTION
Currently, when a new connection is created and the connection pool reaches its maximum size, it just removes some old connection, but without closing. So it is possible to end up with lots of lingering opened connections, which will not be reused and waste process' opened fds. 

This PR makes sure to close discarded connections.