### PR TITLE
Use cgi/escape or cgi/util instead of the all of CGI features

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -1,6 +1,10 @@
 require 'net/http'
 require 'uri'
-require 'cgi' # for escaping
+begin
+  require 'cgi/escape'
+rescue LoadError
+  require 'cgi/util' # for escaping
+end
 require 'connection_pool'
 
 begin
@@ -826,7 +830,7 @@ class Net::HTTP::Persistent
       @proxy_connection_id = [nil, *@proxy_args].join ':'
 
       if @proxy_uri.query then
-        @no_proxy = CGI.parse(@proxy_uri.query)['no_proxy'].join(',').downcase.split(',').map { |x| x.strip }.reject { |x| x.empty? }
+        @no_proxy = URI.decode_www_form(@proxy_uri.query).filter_map { |k, v| v if k == 'no_proxy' }.join(',').downcase.split(',').map { |x| x.strip }.reject { |x| x.empty? }
       end
     end
 


### PR DESCRIPTION
I have a plan to retire CGI library from the next stable version of ruby. see https://bugs.ruby-lang.org/issues/21258

This PR makes to remove `cgi` and use minimum set of `CGI.escape` and `CGI.unescape` on `net-http-persistent`.