### PR TITLE
Fix leaking connections when removing idle connections

### DIFF
--- a/lib/net/http/persistent/timed_stack_multi.rb
+++ b/lib/net/http/persistent/timed_stack_multi.rb
@@ -66,6 +66,7 @@ class Net::HTTP::Persistent::TimedStackMulti < ConnectionPool::TimedStack # :nod
       connection = @ques[oldest].pop
       connection.close if connection.respond_to?(:close)
 
+      @enqueued -= 1
       @created -= 1
     end
 


### PR DESCRIPTION
When removing idle connections by LRU, it was possible to have more connections than is allowed by pool size.