### PR TITLE
Add ignore eof

### DIFF
--- a/lib/net/http/persistent.rb
+++ b/lib/net/http/persistent.rb
@@ -476,6 +476,13 @@ class Net::HTTP::Persistent
 
   attr_reader :verify_hostname
 
+
+  ##
+  #  Sets whether to ignore end-of-file when reading a response body
+  #  with Content-Length headers.
+
+  attr_accessor :ignore_eof
+
   ##
   # Creates a new Net::HTTP::Persistent.
   #
@@ -515,6 +522,7 @@ class Net::HTTP::Persistent
     @max_retries      = 1
     @socket_options   = []
     @ssl_generation   = 0 # incremented when SSL session variables change
+    @ignore_eof       = nil
 
     @socket_options << [Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1] if
       Socket.const_defined? :TCP_NODELAY
@@ -643,6 +651,7 @@ class Net::HTTP::Persistent
         reset connection
       end
 
+      http.ignore_eof         = @ignore_eof    if @ignore_eof
       http.keep_alive_timeout = @idle_timeout  if @idle_timeout
       http.max_retries        = @max_retries   if http.respond_to?(:max_retries=)
       http.read_timeout       = @read_timeout  if @read_timeout

--- a/test/test_net_http_persistent.rb
+++ b/test/test_net_http_persistent.rb
@@ -80,7 +80,7 @@ class TestNetHttpPersistent < Minitest::Test
                   :read_timeout, :open_timeout, :keep_alive_timeout
     attr_accessor :ciphers, :ssl_timeout, :ssl_version, :min_version,
                   :max_version, :verify_depth, :verify_mode, :cert_store,
-                  :ca_file, :ca_path, :cert, :key
+                  :ca_file, :ca_path, :cert, :key, :ignore_eof
     attr_reader :req, :debug_output
     def initialize
       @started, @finished = 0, 0
@@ -1528,6 +1528,24 @@ class TestNetHttpPersistent < Minitest::Test
     @http.pool.checkin(force: true)
     @http.pool.reload do |connection|
       connection.close
+    end
+  end
+
+  def test_ignore_eof
+    @http.ignore_eof = true
+
+    connection
+
+    @http.connection_for @uri do |c|
+      assert c.http.ignore_eof
+    end
+
+    @http.ignore_eof = false
+
+    connection
+
+    @http.connection_for @uri do |c|
+      assert !c.http.ignore_eof
     end
   end
 end


### PR DESCRIPTION
Hey guys,

In 3.1.something `ignore_eof` option was added to [Net::HTTP](https://github.com/ruby/net-http/pull/15) to fix a bug where EOFError gets swallowed: https://bugs.ruby-lang.org/issues/14972

Would be awesome to have as an option in the net http persistent