### PR TITLE
Add support for connection_pool >= 3.0

### DIFF
--- a/lib/net/http/persistent/pool.rb
+++ b/lib/net/http/persistent/pool.rb
@@ -4,7 +4,7 @@ class Net::HTTP::Persistent::Pool < ConnectionPool # :nodoc:
   attr_reader :key # :nodoc:
 
   def initialize(options = {}, &block)
-    super
+    super(**options, &block)
 
     @available = Net::HTTP::Persistent::TimedStackMulti.new(@size, &block)
     @key = "current-#{@available.object_id}"

--- a/lib/net/http/persistent/timed_stack_multi.rb
+++ b/lib/net/http/persistent/timed_stack_multi.rb
@@ -1,6 +1,11 @@
 class Net::HTTP::Persistent::TimedStackMulti < ConnectionPool::TimedStack # :nodoc:
 
   ##
+  # Detects if ConnectionPool 3.0+ is being used (needed for TimedStack subclass compatibility)
+
+  CP_USES_KEYWORD_ARGS = Gem::Version.new(ConnectionPool::VERSION) >= Gem::Version.new('3.0.0') # :nodoc:
+
+  ##
   # Returns a new hash that has arrays for keys
   #
   # Using a class method to limit the bindings referenced by the hash's
@@ -11,7 +16,11 @@ class Net::HTTP::Persistent::TimedStackMulti < ConnectionPool::TimedStack # :nod
   end
 
   def initialize(size = 0, &block)
-    super
+    if CP_USES_KEYWORD_ARGS
+      super(size: size, &block)
+    else
+      super(size, &block)
+    end
 
     @enqueued = 0
     @ques = self.class.hash_of_arrays

--- a/net-http-persistent.gemspec
+++ b/net-http-persistent.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.4".freeze
   s.summary = "Manages persistent connections using Net::HTTP including a thread pool for connecting to multiple hosts".freeze
 
-  s.add_runtime_dependency(%q<connection_pool>.freeze, ["~> 2.2", ">= 2.2.4"])
+  s.add_runtime_dependency(%q<connection_pool>.freeze, [">= 2.2.4", "< 4"])
 end
 

--- a/test/test_net_http_persistent_timed_stack_multi.rb
+++ b/test/test_net_http_persistent_timed_stack_multi.rb
@@ -29,7 +29,7 @@ class TestNetHttpPersistentTimedStackMulti < Minitest::Test
 
     assert_empty stack
 
-    stack.push connection_args: popped
+    stack.push popped, connection_args: 'default'
 
     refute_empty stack
   end
@@ -43,7 +43,7 @@ class TestNetHttpPersistentTimedStackMulti < Minitest::Test
 
     assert_equal 0, stack.length
 
-    stack.push connection_args: popped
+    stack.push popped, connection_args: 'default'
 
     assert_equal 1, stack.length
   end
@@ -113,7 +113,7 @@ class TestNetHttpPersistentTimedStackMulti < Minitest::Test
 
     conn = stack.pop
 
-    stack.push connection_args: conn
+    stack.push conn, connection_args: 'default'
 
     refute_empty stack
   end
@@ -125,14 +125,16 @@ class TestNetHttpPersistentTimedStackMulti < Minitest::Test
       called << object
     end
 
-    @stack.push connection_args: Object.new
+    obj = Object.new
+    @stack.push obj, connection_args: 'default'
 
     refute_empty called
     assert_empty @stack
   end
 
   def test_shutdown
-    @stack.push connection_args: Object.new
+    obj = Object.new
+    @stack.push obj, connection_args: 'default'
 
     called = []
 


### PR DESCRIPTION
- Added support for connection_pool >= 3.0 (https://github.com/drbrain/net-http-persistent/issues/162) by adapting to ConnectionPool 3.x's keyword argument requirements. `Pool#initialize` was simplified to use `**options` syntax (compatible with both versions), while `TimedStackMulti#initialize` uses conditional logic based on ConnectionPool version due to different subclass super() behavior.
-  Fixed confusing test syntax that relied on Ruby's keyword-to-hash conversion behavior. For example here, I think we were actually using `{ connection_args: popped }` as the `obj` (https://github.com/mperham/connection_pool/blob/v2.5.5/lib/connection_pool/timed_stack.rb#L38) ? 
```ruby
stack.push connection_args: popped
```
So I added the `connection_args` with another value for clear separation of `obj` and `options` (https://github.com/mperham/connection_pool/blob/v3.0.2/lib/connection_pool/timed_stack.rb#L38)
```ruby
stack.push popped, connection_args: 'default'
```
to make the tests more clear.